### PR TITLE
Pin landing page to assets of v2.0.5 to prevent breakage

### DIFF
--- a/assets
+++ b/assets
@@ -1,1 +1,0 @@
-./latest/assets/

--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
   <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width,initial-scale=1">
-      <link rel="canonical" href="https://iceoryx.io/v2.0.5/">
+      <link rel="canonical" href="https://iceoryx.io">
       <link rel="icon" href="images/favicon.ico">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.1.3">
       <title>Home - iceoryx.io</title>
-      <link rel="stylesheet" href="assets/stylesheets/main.edf004c2.min.css">
-      <link rel="stylesheet" href="assets/stylesheets/palette.e6a45f82.min.css">
+      <link rel="stylesheet" href="v2.0.5/assets/stylesheets/main.edf004c2.min.css">
+      <link rel="stylesheet" href="v2.0.5/assets/stylesheets/palette.e6a45f82.min.css">
       <link rel="stylesheet" href="stylesheets/extra.css">
 
     <script>__md_scope=new URL(".",location),__md_get=(e,_=localStorage,t=__md_scope)=>JSON.parse(_.getItem(t.pathname+"."+e)),__md_set=(e,_,t=localStorage,a=__md_scope)=>{try{t.setItem(a.pathname+"."+e,JSON.stringify(_))}catch(e){}}</script>
@@ -362,10 +362,10 @@ modular design allows custom extension, e.g. GPUs and Hypervisors
     <div class="md-dialog" data-md-component="dialog">
       <div class="md-dialog__inner md-typeset"></div>
     </div>
-    <script id="__config" type="application/json">{"base": ".", "features": ["navigation.indexes"], "translations": {"clipboard.copy": "Copy to clipboard", "clipboard.copied": "Copied to clipboard", "search.config.lang": "en", "search.config.pipeline": "trimmer, stopWordFilter", "search.config.separator": "[\\s\\-]+", "search.placeholder": "Search", "search.result.placeholder": "Type to start searching", "search.result.none": "No matching documents", "search.result.one": "1 matching document", "search.result.other": "# matching documents", "search.result.more.one": "1 more on this page", "search.result.more.other": "# more on this page", "search.result.term.missing": "Missing", "select.version.title": "Select version"}, "search": "assets/javascripts/workers/search.0bbba5b5.min.js", "version": {"provider": "mike"}}</script>
+    <script id="__config" type="application/json">{"base": ".", "features": ["navigation.indexes"], "translations": {"clipboard.copy": "Copy to clipboard", "clipboard.copied": "Copied to clipboard", "search.config.lang": "en", "search.config.pipeline": "trimmer, stopWordFilter", "search.config.separator": "[\\s\\-]+", "search.placeholder": "Search", "search.result.placeholder": "Type to start searching", "search.result.none": "No matching documents", "search.result.one": "1 matching document", "search.result.other": "# matching documents", "search.result.more.one": "1 more on this page", "search.result.more.other": "# more on this page", "search.result.term.missing": "Missing", "select.version.title": "Select version"}, "search": "v2.0.5/assets/javascripts/workers/search.0bbba5b5.min.js", "version": {"provider": "mike"}}</script>
 
 
-      <script src="assets/javascripts/bundle.e1a181d9.min.js"></script>
+      <script src="v2.0.5/assets/javascripts/bundle.e1a181d9.min.js"></script>
 
 
   </body>


### PR DESCRIPTION
Since v2.0.6 will be created with a newer mkdocs, it will break the layout of the github links in the lower right corner of the landing page. Therefore the assets are pined to the v2.0.5 version